### PR TITLE
Use new style exceptions in Python 2 and 3

### DIFF
--- a/app/controller/api/views.py
+++ b/app/controller/api/views.py
@@ -17,7 +17,7 @@ def search_anomaly(request):
         try:
             anomaly_service = AnomalyService()
             return_dict = anomaly_service.query_anomaly(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -30,7 +30,7 @@ def import_sample(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.import_file(request.FILES)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -43,7 +43,7 @@ def update_sample(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.update_sample(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -56,7 +56,7 @@ def query_sample(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.query_sample(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -69,7 +69,7 @@ def update_anomaly(request):
         try:
             sample_service = AnomalyService()
             return_dict = sample_service.update_anomaly(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -82,7 +82,7 @@ def train(request):
         try:
             detect_service = DetectService()
             return_dict = detect_service.process_train(json.loads(request.body))
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -100,7 +100,7 @@ def download_sample(request):
             response['Content-Type'] = 'application/octet-stream'
             response['Content-Disposition'] = 'attachment;filename = "SampleExport.csv"'
             return response
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -113,7 +113,7 @@ def predict_rate(request):
         try:
             detect_service = DetectService()
             return_dict = detect_service.rate_predict(json.loads(request.body))
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -126,7 +126,7 @@ def predict_value(request):
         try:
             detect_service = DetectService()
             return_dict = detect_service.value_predict(json.loads(request.body))
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -139,7 +139,7 @@ def query_train_task(request):
         try:
             train_service = TrainService()
             return_dict = train_service.query_train(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -152,7 +152,7 @@ def query_train_source(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.query_sample_source()
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -165,7 +165,7 @@ def delete_train_task(request):
         try:
             train_service = TrainService()
             return_dict = train_service.delete_train(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -178,7 +178,7 @@ def delete_sample(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.delete_sample(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:
@@ -191,7 +191,7 @@ def count_sample(request):
         try:
             sample_service = SampleService()
             return_dict = sample_service.count_sample(request.body)
-        except Exception, ex:
+        except Exception as ex:
             return_dict = build_ret_data(THROW_EXP, str(ex))
             return render_json(return_dict)
     else:

--- a/app/service/time_series_detector/algorithm/gbdt.py
+++ b/app/service/time_series_detector/algorithm/gbdt.py
@@ -82,7 +82,7 @@ class Gbdt(object):
             grd.fit(X_train, y_train)
             model_name = MODEL_PATH + task_id + "_model"
             joblib.dump(grd, model_name)
-        except Exception, ex:
+        except Exception as ex:
             return TRAIN_ERR, str(ex)
         return OP_SUCCESS, ""
 

--- a/app/service/time_series_detector/algorithm/xgboosting.py
+++ b/app/service/time_series_detector/algorithm/xgboosting.py
@@ -74,7 +74,7 @@ class XGBoosting(object):
         """
         try:
             f = open(feature_file_name, "w")
-        except Exception, ex:
+        except Exception as ex:
             return CAL_FEATURE_ERR, str(ex)
         times = 0
         for temp in data:
@@ -104,7 +104,7 @@ class XGBoosting(object):
                 features.append(temp)
         try:
             ret_code, ret_data = self.__save_libsvm_format(features, feature_file_name)
-        except Exception, ex:
+        except Exception as ex:
             ret_code = CAL_FEATURE_ERR
             ret_data = str(ex)
         return ret_code, ret_data
@@ -124,7 +124,7 @@ class XGBoosting(object):
             return ret_code, ret_data
         try:
             dtrain = xgb.DMatrix(feature_file_name)
-        except Exception, ex:
+        except Exception as ex:
             return READ_FEATURE_FAILED, str(ex)
         params = {
             'max_depth': self.max_depth,
@@ -141,7 +141,7 @@ class XGBoosting(object):
         try:
             bst = xgb.train(params, dtrain, num_round)
             bst.save_model(model_name)
-        except Exception, ex:
+        except Exception as ex:
             return TRAIN_ERR, str(ex)
         return OP_SUCCESS, ""
 

--- a/app/service/time_series_detector/anomaly_service.py
+++ b/app/service/time_series_detector/anomaly_service.py
@@ -7,6 +7,7 @@ Licensed under the BSD 3-Clause License (the "License"); you may not use this fi
 https://opensource.org/licenses/BSD-3-Clause
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 """
+from __future__ import print_function
 
 import json
 import traceback
@@ -26,7 +27,7 @@ class AnomalyService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__anomaly.get_anomaly(form)
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -36,11 +37,11 @@ class AnomalyService(object):
             form = json.loads(body)
             ret_code, ret_data = check_value(form)
             if OP_SUCCESS == ret_code:
-                print form
+                print(form)
                 ret_code, ret_data = self.__anomaly.update_anomaly(form)
             return_dict = build_ret_data(ret_code, ret_data)
 
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict

--- a/app/service/time_series_detector/sample_service.py
+++ b/app/service/time_series_detector/sample_service.py
@@ -28,7 +28,7 @@ class SampleService(object):
         try:
             ret_code, ret_data = self.__sample.import_sample(data)
             return_dict = build_ret_data(ret_code, {"count": ret_data})
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -70,7 +70,7 @@ class SampleService(object):
                 elif row[6] == "negative":
                     negative_count = negative_count + 1
                 count = count + 1
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(FILE_FORMAT_ERR, str(ex))
             return return_dict
@@ -88,7 +88,7 @@ class SampleService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__sample.update_sample(form)
             return_dict = build_ret_data(ret_code, {"count": ret_data})
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -100,7 +100,7 @@ class SampleService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__sample.query_sample(form)
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -111,7 +111,7 @@ class SampleService(object):
             if len(body) > VALUE_LEN_MAX:
                 return ""
             ret_data = self.__sample.download_sample(body)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             ret_data = build_ret_data(THROW_EXP, str(ex))
         return ret_data
@@ -123,7 +123,7 @@ class SampleService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__sample.delete_sample(form)
             return_dict = build_ret_data(ret_code, {"count": ret_data})
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -135,7 +135,7 @@ class SampleService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__sample.sample_count(form)
             return_dict = build_ret_data(ret_code, {"count": ret_data})
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -144,7 +144,7 @@ class SampleService(object):
         try:
             ret_code, ret_data = self.__sample.query_sample_source()
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict

--- a/app/service/time_series_detector/task_service.py
+++ b/app/service/time_series_detector/task_service.py
@@ -27,7 +27,7 @@ class TrainService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__train_op.query_train(form)
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -36,7 +36,7 @@ class TrainService(object):
         try:
             ret_code, ret_data = self.__train_op.query_train_source()
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict
@@ -48,7 +48,7 @@ class TrainService(object):
             if OP_SUCCESS == ret_code:
                 ret_code, ret_data = self.__train_op.delete_train(form)
             return_dict = build_ret_data(ret_code, ret_data)
-        except Exception, ex:
+        except Exception as ex:
             traceback.print_exc()
             return_dict = build_ret_data(THROW_EXP, str(ex))
         return return_dict


### PR DESCRIPTION
Old style exceptions are a syntax error in Python 3 but new style exceptions work on both Python 2 and Python 3.