### PR TITLE
Travis CI: Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: python
  
 python:
     - "2.7"
+    - "3.6"
 
 node_js: "8"
 
+matrix:
+    allow_failures:
+        - python: "3.6"
 
 install:
     - pip install tsfresh==0.11.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - pip install tsfresh==0.11.1
     - pip install django==1.11.13
     - pip install pylint
-    - pip install mysql-python
+    - pip install mysqlclient
     - pip install scikit-learn
     - npm install
 


### PR DESCRIPTION
With just 437 days until the end of life of Python 2, porting to Python 3 should begin.  http://pythonclock.org