### PR TITLE
pip install MySQL-python==1.2.5 failing without mysqlclient

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mysqlclient==1.4.6
+mysqlclient==1.3.9
 Django==1.10.3
 MySQL-python==1.2.5
 numpy==1.15.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+mysqlclient==1.4.6
 Django==1.10.3
 MySQL-python==1.2.5
 numpy==1.15.2


### PR DESCRIPTION
pip install MySQL-python==1.2.5 failing without mysqlclient